### PR TITLE
[No ticket] Minor padding added to the logo in the English version

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,6 +36,14 @@ a.site-logo img {
   a.site-logo img {
     height:5rem;
   }
+
+  a.site-logo {
+    padding-right: 1.5em;
+  }
+
+  html[dir="rtl"] a.site-logo {
+    padding-right: 15px;
+  }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
Adding a bit of padding to the logo in the English version, since it was too close to the language switcher (reported by @Inwerpsel ).

Before:
<img width="165" alt="Captura de pantalla 2020-10-21 a la(s) 15 24 01" src="https://user-images.githubusercontent.com/340766/96769551-a8fb9380-13b5-11eb-9813-f99f2b6106b5.png">


![Captura de pantalla 2020-10-21 a la(s) 15 24 18](https://user-images.githubusercontent.com/340766/96769554-aac55700-13b5-11eb-8191-19cfe9f05304.png)

After: 
<img width="177" alt="Captura de pantalla 2020-10-21 a la(s) 15 23 55" src="https://user-images.githubusercontent.com/340766/96769615-bf095400-13b5-11eb-9166-aac8df0cc863.png">
